### PR TITLE
Print generic signal code information

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_SOURCES
   intdiv2.c
   intdiv3.c
   bus.c
+  wait.c
   demangle.c
   )
 

--- a/test/wait.c
+++ b/test/wait.c
@@ -1,0 +1,28 @@
+/* Copyright 2019 Nikoli Dryden
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include "shbt/shbt.h"
+
+// Application that just waits, so you can use kill to send it signals.
+
+int main() {
+  shbt_register_fatal_handlers();
+  while (true) {
+    sleep(1);
+  }
+  return 0;
+}


### PR DESCRIPTION
Generic signal codes can come from many sources, but are mostly useful
for identifying whether a signal was delivered via kill or by the
kernel.

This also adds a wait test, so that signal handlers can be tested by
using kill easily.

Closes #2.